### PR TITLE
Bug Fix: fixes broken slack team links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# [Join the slack team!](dig-eg-gaz.slack.com)
+# [Join the slack team!](https://dig-eg-gaz.slack.com)
+
 All you need is your @my.fsu.edu email address.
 
 If you would like to learn more about Slack, watch [this](https://www.youtube.com/watch?v=B6zVzWU95Sw) video!

--- a/_pages/how-to.md
+++ b/_pages/how-to.md
@@ -24,10 +24,10 @@ header:
 1. [XML to HTML conversion for Egyptian Gazette]
 2. [TEI customizations for Egyptian Gazette]
 
-# [Slack](dig-eg-gaz.github.io)
+# [Slack](http://dig-eg-gaz.slack.com)
 
-Slack has become the standard for business communcation among startups and tech-companies, but has gained a lot of traction with other types of companies in the past year.  Slack serves as an email replacement, putting all conversations in channels where they can stay on topic, and provide a dedicated place for inquiry and discussion.
+Slack has become the standard for business communcation among startups and tech-companies, but has gained a lot of traction with other types of companies in the past year. Slack serves as an email replacement, putting all conversations in channels where they can stay on topic, and provide a dedicated place for inquiry and discussion.
 
 Slack has the web app, [desktop applications](https://slack.com/downloads), and [mobile applications](https://slack.com/downloads).
 
-**But how do I sign up?**  All you need is your _@my.fsu.edu_ email address.  Go to the [page link](dig-eg-gaz.slack.com) and sign up!  Once you have completed your sign-up, make sure to add a profile picture, fill out the rest of the profile information, and introduce yourself in the #general channel.
+**But how do I sign up?** All you need is your _@my.fsu.edu_ email address. Go to the [page link](http://dig-eg-gaz.slack.com) and sign up! Once you have completed your sign-up, make sure to add a profile picture, fill out the rest of the profile information, and introduce yourself in the #general channel.

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -9,7 +9,7 @@ header:
 
 [Github repository](https://github.com/dig-eg-gaz) - containing all the materials used in this project
 
-[Slack Team](dig-eg-gaz.slack.com) - the team where you can communicate with classmates, and get help with the git platform
+[Slack Team](http://dig-eg-gaz.slack.com) - the team where you can communicate with classmates, and get help with the git platform
 
 [Table boilerplates](https://github.com/dig-eg-gaz/boilerplates) - copy and paste for standard-format tables, then fill in the details that change from issue to issue.
 
@@ -21,14 +21,13 @@ header:
 
 [Matthew Miguez’s page](http://myweb.fsu.edu/mmiguez/tei/index.html) - metadata librarian at FSU.
 
-### Slack
+# Slack
 
-[Join the dig-eg-gaz slack team!](http://dig-eg-gaz.slack.com)
-All you need is your @my.fsu.edu email address.
+[Join the dig-eg-gaz slack team!](http://dig-eg-gaz.slack.com) All you need is your @my.fsu.edu email address.
 
 If you would like to learn more about Slack, watch [this](https://www.youtube.com/watch?v=B6zVzWU95Sw) video!
 
-Slack is the standard for communication in technical teams, but it's gaining traction as an email replacement in a very wide variety of companies and organizations.  Slack supports integrations with a wide variety of services and applications.
+Slack is the standard for communication in technical teams, but it's gaining traction as an email replacement in a very wide variety of companies and organizations. Slack supports integrations with a wide variety of services and applications.
 
 **But how does it do its magic?** Slack organizes all communication into dedicated channels, where people can have focused conversations, and can always find a place to ask important questions.
 


### PR DESCRIPTION
Appends http:// to all instances of the slack team link, preventing web browsers
from re-directing students to broken links, by indicating that links to the
slack team are external.